### PR TITLE
only upload logs when there are greater than zero to upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3~=1.4
+doubles~=1.2
 PyMySQL~=0.7
 pytest~=3.0

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+import boto3
 # https://pymysql.readthedocs.io/en/latest/
 import pymysql
 import os
@@ -19,7 +20,8 @@ if __name__ == '__main__':
     conn = pymysql.connect(**DB_KWARGS)
     db = mysql.MySQL(conn)
 
-    cw = cloudwatch.CloudWatch(LOG_GROUP_NAME, LOG_STREAM_NAME)
+    cw_client = boto3.client('logs')
+    cw = cloudwatch.CloudWatch(cw_client, LOG_GROUP_NAME, LOG_STREAM_NAME)
 
     integration.set_up_logs(db, cw)
     integration.run(db, cw)

--- a/src/cloudwatch.py
+++ b/src/cloudwatch.py
@@ -1,10 +1,9 @@
-import boto3
 import datetime
 
 
 class CloudWatch:
-    def __init__(self, group, stream):
-        self.client = boto3.client('logs')
+    def __init__(self, client, group, stream):
+        self.client = client
         self.group = group
         self.stream = stream
 
@@ -52,7 +51,7 @@ class CloudWatch:
 
         return datetime.datetime.utcfromtimestamp(timestamp)
 
-    def upload_logs(self, events, seq_token=None):
+    def upload_logs(self, events):
         print("Uploading {:d} events...".format(len(events)))
 
         # http://stackoverflow.com/a/8686243/358804
@@ -61,6 +60,7 @@ class CloudWatch:
             'logStreamName': self.stream,
             'logEvents': events
         }
+        seq_token = self.get_seq_token()
         if seq_token:
             log_args['sequenceToken'] = seq_token
 

--- a/src/cloudwatch.py
+++ b/src/cloudwatch.py
@@ -52,6 +52,11 @@ class CloudWatch:
         return datetime.datetime.utcfromtimestamp(timestamp)
 
     def upload_logs(self, events):
+        # CloudWatch Logs complains if trying to send zero events
+        # http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#CWL-PutLogEvents-request-logEvents
+        if not events:
+            return
+
         print("Uploading {:d} events...".format(len(events)))
 
         # http://stackoverflow.com/a/8686243/358804

--- a/src/integration.py
+++ b/src/integration.py
@@ -9,7 +9,10 @@ def get_new_db_events(db, cw):
 
 def copy_new_general_logs(db, cw):
     events = get_new_db_events(db, cw)
-    cw.upload_logs(events)
+    # CloudWatch Logs complains if trying to send zero events
+    # http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#CWL-PutLogEvents-request-logEvents
+    if events:
+        cw.upload_logs(events)
 
 def run(db, cw):
     # TODO copy error log

--- a/src/integration.py
+++ b/src/integration.py
@@ -3,13 +3,14 @@ def set_up_logs(db, cw):
     cw.create_log_group()
     cw.create_log_stream()
 
-def copy_general_logs(db, cw, since, seq_token=None):
-    events = db.get_general_log_events(since)
-    cw.upload_logs(events, seq_token=seq_token)
+def get_new_db_events(db, cw):
+    since = cw.get_latest_cw_event()
+    return db.get_general_log_events(since)
+
+def copy_new_general_logs(db, cw):
+    events = get_new_db_events(db, cw)
+    cw.upload_logs(events)
 
 def run(db, cw):
-    since = cw.get_latest_cw_event()
-    seq_token = cw.get_seq_token()
-
     # TODO copy error log
-    copy_general_logs(db, cw, since, seq_token=seq_token)
+    copy_new_general_logs(db, cw)

--- a/src/integration.py
+++ b/src/integration.py
@@ -9,10 +9,7 @@ def get_new_db_events(db, cw):
 
 def copy_new_general_logs(db, cw):
     events = get_new_db_events(db, cw)
-    # CloudWatch Logs complains if trying to send zero events
-    # http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#CWL-PutLogEvents-request-logEvents
-    if events:
-        cw.upload_logs(events)
+    cw.upload_logs(events)
 
 def run(db, cw):
     # TODO copy error log

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,7 +1,16 @@
 import boto3
 from botocore.stub import Stubber
 from doubles import expect
+import pytest
 from ..src import cloudwatch
+
+@pytest.fixture
+def client():
+    return boto3.client('logs', region_name='us-east-1')
+
+@pytest.fixture
+def cw(client):
+    return cloudwatch.CloudWatch(client, 'somegroup', 'somestream')
 
 # TODO test_create_log_group_present
 
@@ -15,8 +24,7 @@ from ..src import cloudwatch
 
 # TODO test_create_log_stream_empty
 
-def test_upload_logs_without_seq_token():
-    client = boto3.client('logs', region_name='us-east-1')
+def test_upload_logs_without_seq_token(client, cw):
     events = [
         {
             'timestamp': 1000,
@@ -35,9 +43,14 @@ def test_upload_logs_without_seq_token():
     stubber.add_response('put_log_events', response, expected_params)
     stubber.activate()
 
-    cw = cloudwatch.CloudWatch(client, 'somegroup', 'somestream')
     expect(cw).get_seq_token.and_return(None)
 
     cw.upload_logs(events)
+
+def test_upload_logs_with_no_events(client, cw):
+    expect(cw).get_seq_token.never()
+    expect(client).put_log_events.never()
+
+    cw.upload_logs([])
 
 # TODO test_upload_logs_with_seq_token

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,3 +1,6 @@
+import boto3
+from botocore.stub import Stubber
+from doubles import expect
 from ..src import cloudwatch
 
 # TODO test_create_log_group_present
@@ -12,6 +15,29 @@ from ..src import cloudwatch
 
 # TODO test_create_log_stream_empty
 
-# TODO test_upload_logs
+def test_upload_logs_without_seq_token():
+    client = boto3.client('logs', region_name='us-east-1')
+    events = [
+        {
+            'timestamp': 1000,
+            'message': 'foo'
+        }
+    ]
 
-# TODO test_upload_logs_without_seq_token
+    stubber = Stubber(client)
+    response = {}
+    expected_params = {
+        'logGroupName': 'somegroup',
+        'logStreamName': 'somestream',
+        'logEvents': events
+    }
+
+    stubber.add_response('put_log_events', response, expected_params)
+    stubber.activate()
+
+    cw = cloudwatch.CloudWatch(client, 'somegroup', 'somestream')
+    expect(cw).get_seq_token.and_return(None)
+
+    cw.upload_logs(events)
+
+# TODO test_upload_logs_with_seq_token

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,29 @@
+from doubles import expect
+import pytest
+from ..src import cloudwatch
+from ..src import integration
+from ..src import mysql
+
+
+@pytest.fixture
+def db():
+    conn = object()
+    return mysql.MySQL(conn)
+
+@pytest.fixture
+def cw():
+    client = object()
+    return cloudwatch.CloudWatch(client, 'somegroup', 'somestream')
+
+def test_copy_new_general_logs(db, cw):
+    expect(cw).get_latest_cw_event.and_return(None)
+    events = [
+        {
+            'time': 1000000,
+            'message': 'foo'
+        }
+    ]
+    expect(db).get_general_log_events.and_return(events)
+    expect(cw).upload_logs.with_args(events)
+
+    integration.copy_new_general_logs(db, cw)


### PR DESCRIPTION
Broken out from #5.

This is a constraint of the CloudWatch Logs API. Also added a number of tests.