### PR TITLE
use time zones for all datetime objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,6 @@ python:
 - '3.6'
 services:
   - docker
-
-# upgrade Docker & Docker Compose
-# https://docs.travis-ci.com/user/docker/
-env:
-  DOCKER_COMPOSE_VERSION: 1.11.2
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 script:
   - docker --version
   - cd tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3~=1.4
 doubles~=1.2
 PyMySQL~=0.7
 pytest~=3.0
+pytz

--- a/src/cloudwatch.py
+++ b/src/cloudwatch.py
@@ -1,4 +1,5 @@
 import datetime
+from . import time_helper
 
 
 class CloudWatch:
@@ -57,7 +58,13 @@ class CloudWatch:
         if not events:
             return
 
-        print("Uploading {:d} events...".format(len(events)))
+        first_time = events[0]['timestamp']
+        last_time = events[-1]['timestamp']
+        print("Uploading {:d} events, from {} to {}...".format(
+            len(events),
+            time_helper.timestamp_str(first_time),
+            time_helper.timestamp_str(last_time)
+        ))
 
         # http://stackoverflow.com/a/8686243/358804
         log_args = {

--- a/src/cloudwatch.py
+++ b/src/cloudwatch.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 from . import time_helper
 
 
@@ -50,7 +50,7 @@ class CloudWatch:
             # no previous event - query since the epoch
             timestamp = 0
 
-        return datetime.datetime.utcfromtimestamp(timestamp)
+        return datetime.fromtimestamp(timestamp, timezone.utc)
 
     def upload_logs(self, events):
         # CloudWatch Logs complains if trying to send zero events

--- a/src/integration.py
+++ b/src/integration.py
@@ -1,3 +1,6 @@
+from . import time_helper
+
+
 def set_up_logs(db, cw):
     db.enable_logs()
     cw.create_log_group()
@@ -5,6 +8,8 @@ def set_up_logs(db, cw):
 
 def get_new_db_events(db, cw):
     since = cw.get_latest_cw_event()
+    if since:
+        time_helper.validate_time_zone(since)
     return db.get_general_log_events(since)
 
 def copy_new_general_logs(db, cw):

--- a/src/mysql.py
+++ b/src/mysql.py
@@ -1,3 +1,6 @@
+from . import time_helper
+
+
 def datetime_to_ms_since_epoch(dt):
     return int(dt.timestamp() * 1000.0)
 
@@ -40,7 +43,7 @@ class MySQL:
         """Returns them in CloudWatch Logs format."""
 
         with self.conn.cursor() as cursor:
-            print("Retrieving events since {:%Y-%m-%d %H:%M:%S}...".format(since))
+            print("Retrieving events from MySQL since {}...".format(time_helper.datetime_str(since)))
             # TODO remove hack for only being able to upload < 10000 events at a time
             # http://stackoverflow.com/a/12125925/358804
             cursor.execute("""

--- a/src/mysql.py
+++ b/src/mysql.py
@@ -1,3 +1,4 @@
+import pytz
 from . import time_helper
 
 
@@ -5,6 +6,10 @@ def mysql_to_cw_log_event(row):
     event_time = row[0]
     cmd = row[1]
     query = row[2].decode("utf-8")
+
+    if not event_time.tzname():
+        # assume UTC
+        event_time = pytz.utc.localize(event_time)
 
     msg = cmd
     if query:

--- a/src/mysql.py
+++ b/src/mysql.py
@@ -1,9 +1,6 @@
 from . import time_helper
 
 
-def datetime_to_ms_since_epoch(dt):
-    return int(dt.timestamp() * 1000.0)
-
 def mysql_to_cw_log_event(row):
     event_time = row[0]
     cmd = row[1]
@@ -14,7 +11,7 @@ def mysql_to_cw_log_event(row):
         msg += ': ' + query
 
     return {
-        'timestamp': datetime_to_ms_since_epoch(event_time),
+        'timestamp': time_helper.datetime_to_ms_since_epoch(event_time),
         'message': msg
     }
 

--- a/src/time_helper.py
+++ b/src/time_helper.py
@@ -1,10 +1,16 @@
 from datetime import datetime, timezone
 
 
+def validate_time_zone(dt):
+    if not dt.tzname():
+        raise ValueError("Missing time zone")
+
 def datetime_to_ms_since_epoch(dt):
+    validate_time_zone(dt)
     return int(dt.timestamp() * 1000.0)
 
 def datetime_str(dt):
+    validate_time_zone(dt)
     return "{:%Y-%m-%d %H:%M:%S.%f %z}".format(dt)
 
 def timestamp_str(timestamp_ms):

--- a/src/time_helper.py
+++ b/src/time_helper.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timezone
 
 
+def datetime_to_ms_since_epoch(dt):
+    return int(dt.timestamp() * 1000.0)
+
 def datetime_str(dt):
     return "{:%Y-%m-%d %H:%M:%S.%f %z}".format(dt)
 

--- a/src/time_helper.py
+++ b/src/time_helper.py
@@ -1,0 +1,9 @@
+from datetime import datetime, timezone
+
+
+def datetime_str(dt):
+    return "{:%Y-%m-%d %H:%M:%S.%f %z}".format(dt)
+
+def timestamp_str(timestamp_ms):
+    dt = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+    return datetime_str(dt)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -61,7 +61,7 @@ def test_get_general_log_events(conn, db):
         for query in queries:
             cursor.execute(query)
         conn.commit()
-    since = datetime.utcfromtimestamp(0)
+    since = datetime.fromtimestamp(0, timezone.utc)
 
     events = db.get_general_log_events(since)
 
@@ -70,13 +70,13 @@ def test_get_general_log_events_limit(conn, db):
         for i in range(6):
             cursor.execute("SELECT 1")
         conn.commit()
-    since = datetime.utcfromtimestamp(0)
+    since = datetime.fromtimestamp(0, timezone.utc)
 
     limit = 2
     events = db.get_general_log_events(since, limit=limit)
     assert len(events) == limit
 
 def test_get_general_log_events_empty(db):
-    since = datetime.utcfromtimestamp(0)
+    since = datetime.fromtimestamp(0, timezone.utc)
     events = db.get_general_log_events(since)
     assert len(events) == BASELINE_NUM_EVENTS + 1

--- a/tests/test_time_helper.py
+++ b/tests/test_time_helper.py
@@ -1,0 +1,8 @@
+from datetime import datetime, timezone
+from ..src import time_helper
+
+
+def test_datetime_str():
+    dt = datetime(2010, 1, 1, tzinfo=timezone.utc)
+    result = time_helper.datetime_str(dt)
+    assert result == "2010-01-01 00:00:00.000000 +0000"

--- a/tests/test_time_helper.py
+++ b/tests/test_time_helper.py
@@ -1,8 +1,17 @@
-from datetime import datetime, timezone
+from datetime import datetime
+import pytz
 from ..src import time_helper
 
 
+def test_datetime_to_ms_since_epoch_tzs():
+    eastern = pytz.timezone('US/Eastern')
+    now = datetime.now(eastern)
+
+    expected = datetime.now(pytz.utc).timestamp() * 1000
+    actual = time_helper.datetime_to_ms_since_epoch(now)
+    assert abs(actual - expected) < 10
+
 def test_datetime_str():
-    dt = datetime(2010, 1, 1, tzinfo=timezone.utc)
+    dt = datetime(2010, 1, 1, tzinfo=pytz.utc)
     result = time_helper.datetime_str(dt)
     assert result == "2010-01-01 00:00:00.000000 +0000"


### PR DESCRIPTION
Broken out from #5.

There doesn't seem to be a way to enforce this in Python, so add a bunch of checks to ensure the timezone is set on `Datetime` objects being passed around. Also added some more detailed logging of the timestamps to show the time ranges with the timezone included.