### PR TITLE
handle enabling of logs gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a script that grabs logs from MySQL and sends them to CloudWatch Logs.
 
 ## Setup
 
-1. Enable the desired logs. More information:
+1. Enable the desired logs. The script will attempt to do so for you, but may fail (gracefully), based on if the user has permissions or not. More information:
     * [Amazon Web Services (AWS) Relational Database Service (RDS)](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.MySQL.html)
     * [MySQL (self-hosted)](https://dev.mysql.com/doc/refman/5.7/en/server-logs.html)
 1. Create [a `.env` file](https://docs.docker.com/compose/environment-variables/#the-env-file) with your AWS connection information and other environment variables. See [`docker-compose.yml`](docker-compose.yml) for the list of supported variables.

--- a/src/mysql.py
+++ b/src/mysql.py
@@ -1,4 +1,6 @@
+import pymysql
 import pytz
+import sys
 from contextlib import contextmanager
 from . import time_helper
 
@@ -40,8 +42,15 @@ class MySQL:
 
     def enable_logs(self):
         with self.transact() as cursor:
-            cursor.execute("SET GLOBAL log_output = 'TABLE'")
-            cursor.execute("SET GLOBAL general_log = 'ON'")
+            try:
+                cursor.execute("SET GLOBAL log_output = 'TABLE'")
+                cursor.execute("SET GLOBAL general_log = 'ON'")
+            except pymysql.err.DatabaseError as err:
+                code = err.args[0]
+                if code == pymysql.constants.ER.SPECIFIC_ACCESS_DENIED_ERROR:
+                    print("Unable to enable logging in MySQL - you will need to ensure that it's enabled.", file=sys.stderr)
+                else:
+                    raise
 
     def clear_logs(self):
         with self.transact() as cursor:

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -57,6 +57,19 @@ def test_mysql_to_cw_log_event_no_tz():
         'message': 'Query: SELECT * FROM sometable'
     }
 
+def test_enable_logs_permission_denied(db):
+    with db.transact() as cursor:
+        cursor.execute("CREATE USER IF NOT EXISTS 'nonsuper'@'%'")
+        cursor.execute("GRANT SELECT ON *.* TO 'nonsuper'@'%'")
+
+    conn2 = pymysql.connect(host='mysql', db='mysql', user='nonsuper')
+    try:
+        db2 = mysql.MySQL(conn2)
+        db2.enable_logs()
+        # shouldn't raise exception
+    finally:
+        conn2.close()
+
 def test_clear_logs(db):
     with db.transact() as cursor:
         cursor.execute("SELECT * FROM general_log")

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -57,8 +57,19 @@ def test_mysql_to_cw_log_event_no_tz():
         'message': 'Query: SELECT * FROM sometable'
     }
 
+def test_enable_logs_skip_if_enabled(db):
+    start = datetime.now(tz=timezone.utc)
+
+    db.enable_logs()
+
+    events = db.get_general_log_events(start)
+    print(events)
+    for event in events:
+        assert 'SET ' not in event['message']
+
 def test_enable_logs_permission_denied(db):
     with db.transact() as cursor:
+        cursor.execute("SET GLOBAL general_log = 'OFF'")
         cursor.execute("CREATE USER IF NOT EXISTS 'nonsuper'@'%'")
         cursor.execute("GRANT SELECT ON *.* TO 'nonsuper'@'%'")
 
@@ -87,6 +98,7 @@ def test_get_general_log_events(db):
     since = datetime.fromtimestamp(0, timezone.utc)
 
     events = db.get_general_log_events(since)
+    # TODO assert
 
 def test_get_general_log_events_limit(db):
     with db.transact() as cursor:


### PR DESCRIPTION
Adapted from #5.

The script is now more sensitive to database permission constraints, where it will first check if the logs are already enabled, and if not, attempt to enable them (failing gracefully). This will be a more seamless experience for users.