### PR TITLE
fail Travis build when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - docker --version
   - cd tests
   - docker-compose up -d mysql
-  - docker-compose up tests
+  - docker-compose run tests

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ This is a script that grabs logs from MySQL and sends them to CloudWatch Logs.
 ```sh
 cd tests
 
-docker-compose up -d mysql
-# alternatively, run in a separate terminal without the `-d`
+docker-compose up mysql
+# this will print out a bunch of junk you can probably ignore
 
-docker-compose up tests
+# in another terminal
+docker-compose run tests
 ```
 
 ## Troubleshooting

--- a/src/mysql.py
+++ b/src/mysql.py
@@ -54,7 +54,7 @@ class MySQL:
             print("Setting {}={}...".format(var, val))
             try:
                 # http://stackoverflow.com/a/10077141/358804
-                cursor.execute("SET GLOBAL {} = {}".format(var, val))
+                cursor.execute("SET GLOBAL {} = %s".format(var), (val, ))
             except pymysql.err.DatabaseError as err:
                 code = err.args[0]
                 if code == pymysql.constants.ER.SPECIFIC_ACCESS_DENIED_ERROR:


### PR DESCRIPTION
Apparently `docker-compose up` will always exit with code 0. Need to use `docker-compose run` instead.

https://stackoverflow.com/questions/29568352/using-docker-compose-with-ci-how-to-deal-with-exit-codes-and-daemonized-linked

I suggest we merge this sooner than later, ~~since the build is rightfully failing~~.

/cc @LindsayYoung